### PR TITLE
Open the web app right when gocho start serving. Additional fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+build/

--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,4 @@ clean-dashboard:
 
 ui: clean-dashboard
 	cd ui \
-	&& npm install \
 	&& yarn build

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 VERSION = 0.2.0
+GOPATH := $(PWD)/build:$(GOPATH)
 
 build-dev:
 	@echo "Building gocho"
+	rm -rf build && mkdir -p build/src/github.com/donkeysharp
+	ln -s $(PWD) $(PWD)/build/src/github.com/donkeysharp/gocho
 	go install -i github.com/donkeysharp/gocho/cmd/gocho
 
 clean:
 	rm -rf dist/*
+	rm -rf build
 
 dist: clean ui generate
 	@echo "Building gocho for Linux x86_64..."
@@ -54,4 +58,5 @@ clean-dashboard:
 
 ui: clean-dashboard
 	cd ui \
+	&& npm install \
 	&& yarn build

--- a/pkg/node/dashboard.go
+++ b/pkg/node/dashboard.go
@@ -7,6 +7,7 @@ import (
 	"github.com/donkeysharp/gocho/assets"
 	"github.com/donkeysharp/gocho/pkg/config"
 	"net/http"
+	"log"
 )
 
 func configHandler(conf *config.Config) func(w http.ResponseWriter, r *http.Request) {
@@ -52,6 +53,10 @@ func dashboardServe(conf *config.Config, nodeList *list.List) {
 	if conf.Debug {
 		address = "0.0.0.0"
 	}
-	fmt.Printf("Starting dashboard at %s\n", address)
-	http.ListenAndServe(fmt.Sprintf("%s:%s", address, conf.LocalPort), dashboardMux)
+
+	fmt.Printf("Starting dashboard at %s:%s\n", address, conf.LocalPort)
+	err := http.ListenAndServe(fmt.Sprintf("%s:%s", address, conf.LocalPort), dashboardMux)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/node/serve.go
+++ b/pkg/node/serve.go
@@ -20,6 +20,9 @@ func Serve(conf *config.Config) {
 	go fileServe(conf)
 	go dashboardServe(conf, nodeList)
 
+	// Enhancement. Open the UI app in a browser
+	openUrl("http://localhost:" + conf.LocalPort)
+
 	for {
 		time.Sleep(time.Minute * 15)
 	}

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -8,18 +8,18 @@ import (
 // https://stackoverflow.com/a/39324149/916063
 // open opens the specified URL in the default browser of the user.
 func openUrl(url string) error {
-    var cmd string
-    var args []string
+	var cmd string
+	var args []string
 
-    switch runtime.GOOS {
-    case "windows":
-        cmd = "cmd"
-        args = []string{"/c", "start"}
-    case "darwin":
-        cmd = "open"
-    default: // "linux", "freebsd", "openbsd", "netbsd"
-        cmd = "xdg-open"
-    }
-    args = append(args, url)
-    return exec.Command(cmd, args...).Start()
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
 }

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -1,0 +1,25 @@
+package node
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// https://stackoverflow.com/a/39324149/916063
+// open opens the specified URL in the default browser of the user.
+func openUrl(url string) error {
+    var cmd string
+    var args []string
+
+    switch runtime.GOOS {
+    case "windows":
+        cmd = "cmd"
+        args = []string{"/c", "start"}
+    case "darwin":
+        cmd = "open"
+    default: // "linux", "freebsd", "openbsd", "netbsd"
+        cmd = "xdg-open"
+    }
+    args = append(args, url)
+    return exec.Command(cmd, args...).Start()
+}


### PR DESCRIPTION
Right after gocho starts serving the web app will  automatically be opened in the default OS web browser.
Fixes #13 

iaMtHeWaRlUs